### PR TITLE
Added close function.

### DIFF
--- a/docs/Node/ReadLine.md
+++ b/docs/Node/ReadLine.md
@@ -63,6 +63,14 @@ createInterface :: forall eff. Completer eff -> Eff (console :: CONSOLE | eff) I
 
 Create an interface with the specified completion function.
 
+#### `close`
+
+``` purescript
+close :: forall eff. Interface -> Eff (console :: CONSOLE | eff) Interface
+```
+
+Close the specified `Interface`.
+
 #### `noCompletion`
 
 ``` purescript

--- a/src/Node/ReadLine.js
+++ b/src/Node/ReadLine.js
@@ -46,3 +46,10 @@ exports.createInterface = function(completer) {
         });
     };
 };
+
+exports.close = function(readline) {
+    return function() {
+        readline.close();
+        return readline;
+    };
+};

--- a/src/Node/ReadLine.purs
+++ b/src/Node/ReadLine.purs
@@ -33,6 +33,9 @@ foreign import setPrompt :: forall eff. String -> Int -> Interface -> Eff (conso
 -- | Create an interface with the specified completion function.
 foreign import createInterface :: forall eff. Completer eff -> Eff (console :: CONSOLE | eff) Interface
 
+-- | Close the specified `Interface`.
+foreign import close :: forall eff. Interface -> Eff (console :: CONSOLE | eff) Interface
+
 -- | A completion function which offers no completions.
 noCompletion :: forall eff. Completer eff
 noCompletion s = return { completions: [], matched: s }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,8 +12,12 @@ main = do
   
   let
     lineHandler s = do
-      log $ "You typed: " ++ s
-      prompt interface
+      if s == "quit"
+        then do
+          close interface
+        else do
+          log $ "You typed: " ++ s
+          prompt interface
   
   setPrompt "> " 2 interface
   prompt interface


### PR DESCRIPTION
Unless I missed something, there wasn't a way to close an interface other than to Ctrl+c. 
