### PR TITLE
Changed protocol used in bower.json so I could upload to pursuit.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:purescript-node/purescript-node-readline.git"
+    "url": "git://github.com/purescript-node/purescript-node-readline.git"
   },
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
Without this psc-publish gave the following error:

```
There is a problem with your package, which meant that it could not be         
published.                                                                     
Details:                                                                       
  The repository url in your bower.json file does not point to a GitHub        
  repository. Currently, Pursuit does not support packages which are not hosted
  on GitHub.                                                                   

  Please update your bower.json file to point to a GitHub repository.          
  Alternatively, if you would prefer not to host your package on GitHub, please
  open an issue:                                                               
    https://github.com/purescript/purescript/issues/new      
```
