### PR TITLE
fixed completion bug

### DIFF
--- a/src/Node/ReadLine.js
+++ b/src/Node/ReadLine.js
@@ -11,7 +11,7 @@ exports.createInterfaceImpl = function(options) {
       output: options.output,
       completer: options.completer && function(line) {
         var res = options.completer(line)();
-        return [res.completions, res.suffix];
+        return [res.completions, res.matched];
       },
       terminal: options.terminal,
       historySize: options.historySize


### PR DESCRIPTION
The old code leads to a "cannot read property 'length' of undefined" error since it's trying to access the `suffix` property which doesn't exist, due to the type of the object being `{ completions :: Array String, matched :: String }`.
