### PR TITLE
Fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A low-level PureScript interface to the Node `readline` API.
 ## Installation
 
 ```
-bower install purescript-readline
+bower install purescript-node-readline
 ```
 
 Module documentation can be found on [Pursuit](https://pursuit.purescript.org/packages/purescript-node-readline)


### PR DESCRIPTION
Is the command line in README incorrect?

```
~/  bower install purescript-readline --save
bower                        ENOTFOUND Package purescript-readline not found
~/  bower install purescript-node-readline --save                                                                                                      ⏎
bower purescript-node-readline#*       not-cached https://github.com/purescript/purescript-node-readline.git#*
bower purescript-node-readline#*          resolve https://github.com/purescript/purescript-node-readline.git#*
bower purescript-node-readline#*         checkout v0.5.0
...
...
```
