### PR TITLE
Relax upper bound to allow building with latest node-process

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "purescript-console": "^3.0.0",
     "purescript-node-streams": "^3.0.0",
-    "purescript-node-process": "^4.0.0",
+    "purescript-node-process": ">= 4.0.0 <6.0.0",
     "purescript-options": "^3.0.0",
     "purescript-foreign": "^4.0.0"
   }


### PR DESCRIPTION
We don't use any part of `node-process` which changed in the bump to
version 5.0.0, so nothing beyond this needs doing.