### PR TITLE
Remove `length` parameter to `setPrompt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.0-rc3"
+          purescript: "0.14.0-rc5"
 
       - uses: actions/setup-node@v1
         with:

--- a/src/Node/ReadLine.js
+++ b/src/Node/ReadLine.js
@@ -45,11 +45,9 @@ exports.question = function (text) {
 };
 
 exports.setPrompt = function (prompt) {
-  return function (length) {
-    return function (readline) {
-      return function () {
-        readline.setPrompt(prompt, length);
-      };
+  return function (readline) {
+    return function () {
+      readline.setPrompt(prompt);
     };
   };
 };

--- a/src/Node/ReadLine.purs
+++ b/src/Node/ReadLine.purs
@@ -98,7 +98,6 @@ foreign import question
 -- | Set the prompt.
 foreign import setPrompt
   :: String
-  -> Int
   -> Interface
   -> Effect Unit
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,7 +10,7 @@ import Node.ReadLine (prompt, close, setLineHandler, setPrompt,  noCompletion, c
 main :: Effect Unit
 main = do
   interface <- createConsoleInterface noCompletion
-  setPrompt "> " 2 interface
+  setPrompt "> " interface
   prompt interface
   setLineHandler interface $ \s ->
     if s == "quit"


### PR DESCRIPTION
`length` is nowhere in the [node-readline documentation](https://nodejs.org/api/readline.html#readline_rl_setprompt_prompt). Seems something left over from long ago.

This has been bugging me for a while and since this came up to my attention recently I decided to update `setPrompt` and remove the `length` parameter which isn't used by `node`.