### PR TITLE
Consistent Interface parameter placement

### DIFF
--- a/src/Node/ReadLine.js
+++ b/src/Node/ReadLine.js
@@ -52,8 +52,8 @@ exports.setPrompt = function (prompt) {
   };
 };
 
-exports.setLineHandler = function (readline) {
-  return function (callback) {
+exports.setLineHandler = function (callback) {
+  return function (readline) {
     return function () {
       readline.removeAllListeners("line");
       readline.on("line", function (line) {

--- a/src/Node/ReadLine.purs
+++ b/src/Node/ReadLine.purs
@@ -65,7 +65,7 @@ type Completer
 -- | Builds an interface with the specified options.
 createInterface
   :: forall r
-   .  Readable r
+   . Readable r
   -> Options InterfaceOptions
   -> Effect Interface
 createInterface input opts = createInterfaceImpl
@@ -110,6 +110,6 @@ type LineHandler a = String -> Effect a
 -- | Set the current line handler function.
 foreign import setLineHandler
   :: forall a
-   . Interface
-  -> LineHandler a
+   . LineHandler a
+  -> Interface
   -> Effect Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,9 +12,9 @@ main = do
   interface <- createConsoleInterface noCompletion
   setPrompt "> " interface
   prompt interface
-  setLineHandler interface $ \s ->
+  interface # setLineHandler \s ->
     if s == "quit"
-       then close interface
-       else do
-        log $ "You typed: " <> s
-        prompt interface
+      then close interface
+      else do
+         log $ "You typed: " <> s
+         prompt interface


### PR DESCRIPTION
With this PR I'm just trying to align the placement of `Interface` in
the API, it's just cosmetic, but I find that having `Interface` either
at the beginning (this PR's option) or at the end is desirable.