### PR TITLE
Fix callback invocation for readline.question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Ensure that callbacks passed to `question` and `question'` are invoked
+- Fixed typo in options passed to `readline.createInterface`
 
 Other improvements:
 

--- a/src/Node/ReadLine.js
+++ b/src/Node/ReadLine.js
@@ -14,7 +14,7 @@ export const createInterfaceImpl = (options) => readline.createInterface({
   historySize: options.historySize,
   removeHistoryDuplicates: options.removeHistoryDuplicates,
   prompt: options.prompt,
-  crlDelay: options.crlDelay,
+  crlfDelay: options.crlfDelay,
   escapeCodeTimeout: options.escapeCodeTimeout,
   tabSize: options.tabSize,
   signal: options.signal

--- a/src/Node/ReadLine.purs
+++ b/src/Node/ReadLine.purs
@@ -316,9 +316,9 @@ foreign import promptOptsImpl :: EffectFn2 (Boolean) (Interface) (Unit)
 -- | 
 -- | The callback function passed to `rl.question()` does not follow the typical pattern of accepting an Error object or null as the first argument. The callback is called with the provided answer as the only argument.
 question :: String -> (String -> Effect Unit) -> Interface -> Effect Unit
-question text cb iface = runEffectFn3 questionImpl iface text cb
+question text cb iface = runEffectFn3 questionImpl iface text $ mkEffectFn1 cb
 
-foreign import questionImpl :: EffectFn3 (Interface) (String) ((String -> Effect Unit)) Unit
+foreign import questionImpl :: EffectFn3 (Interface) (String) (EffectFn1 String Unit) Unit
 
 -- | Writes a query to the output, waits
 -- | for user input to be provided on input, then invokes
@@ -338,9 +338,9 @@ foreign import questionImpl :: EffectFn3 (Interface) (String) ((String -> Effect
 -- | 
 -- | The callback function passed to `rl.question()` does not follow the typical pattern of accepting an Error object or null as the first argument. The callback is called with the provided answer as the only argument.
 question' :: String -> { signal :: AbortSignal } -> (String -> Effect Unit) -> Interface -> Effect Unit
-question' text opts cb iface = runEffectFn4 questionOptsCbImpl iface text opts cb
+question' text opts cb iface = runEffectFn4 questionOptsCbImpl iface text opts $ mkEffectFn1 cb
 
-foreign import questionOptsCbImpl :: EffectFn4 (Interface) (String) { signal :: AbortSignal } ((String -> Effect Unit)) Unit
+foreign import questionOptsCbImpl :: EffectFn4 (Interface) (String) { signal :: AbortSignal } (EffectFn1 String Unit) Unit
 
 -- | The rl.resume() method resumes the input stream if it has been paused.
 resume :: Interface -> Effect Unit


### PR DESCRIPTION
**Description of the change**

I've made two small changes to what I think are bugs. The first bug prevents the `question` and `question'` functions from properly invoking the callback they receive, and the second is a small one-character typo in the options passed to `createInterface`

1. To fix the callback not being invoked, I created a `EffectFn1` and passed that to the ffi impls. The previous code was passing a function that returned an `Effect` but never actually ran that effect.

2. Fixed typo in options passed to createInterface: `s/crlDelay/crlfDelay/`
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
